### PR TITLE
fix: wrong closing tags in xml for README.

### DIFF
--- a/XICamera.Windower/lua/README.md
+++ b/XICamera.Windower/lua/README.md
@@ -16,8 +16,8 @@ settings.xml:
     <global>
 	<cameraDistance>6</cameraDistance>
 	<battleDistance>8.2</battleDistance>
-	<horizontalPanSpeed>3</cameraDistance>
-	<verticalPanSpeed>10.7</battleDistance>
+	<horizontalPanSpeed>3</horizontalPanSpeed>
+	<verticalPanSpeed>10.7</verticalPanSpeed>
     </global>
 </settings>
 ```


### PR DESCRIPTION
Was setting this up for the first time and needed to manually create this file. Addon failed to load since these didn't match.

<img width="3032" height="400" alt="{82E7175A-F93D-49C7-A22A-4C94AAA2D775}" src="https://github.com/user-attachments/assets/585ae949-dfa7-43c8-816f-9310eb92ec6b" />
